### PR TITLE
Retain whitespace

### DIFF
--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -38,7 +38,9 @@ module Middleman
           result << tag(:meta, name: name, content: content ) unless content.blank?
         end
 
-        result = result.join("\n")
+        has_padding = @_out_buf.split("\n").last.match(/(\s+)$/)
+
+        result = result.join(has_padding ? "\n#{has_padding[1]}" : "\n")
         result.html_safe
       end
 


### PR DESCRIPTION
Hi, a bit of a ridiculous pull request here, but had a little ocd so, throwing this your way

```erb
    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1" />
    <%= auto_display_meta_tags %>
```

was yielding:

```html
    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1" />
<title>Middleman Meta Tagging</title>
<meta name="keywords" content="code, meta" />
<meta name="twitter:creator" content="@whistlerbrk" />
...
```

but will retain the provided indentation with this commit.

If there is no padding / the tag is placed immediately following another tag, it'll retain the current behaviour