### PR TITLE
Add feature to customize meta tag by each page's frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Then it looks the page meta data to attempt to display the following keys:
 - MM `site` => META `og:site_name`
 - MM `title` => META `og:title`
 
+In addition, if you want to customize meta tags by each page's frontmatter, you
+can add `customize_by_frontmatter: true` in `data/site.yml`. The priority would
+be set_meta_tags > frontmatter > site wide defaults.
+
 ### Manually adding addition tags
 
 Create a helper method inside of your config.rb, like so

--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -81,7 +81,11 @@ module Middleman
     private
 
       def fall_through(site_data, name, key, default = nil)
-        value = self.meta_tags[key] || site_data[key] || default
+        need_customized = site_data[:customize_by_frontmatter]
+        value = self.meta_tags[key] ||
+                (need_customized && current_page.data[key]) ||
+                site_data[key] ||
+                default
         set_meta_tags name => value unless value.blank?
         value
       end


### PR DESCRIPTION
Hi tiste,
I add a new feature that user can easily customise meta tags from page's front matter.
For example, if a page contain `title: "foobar"` in its front matter, then title tag would show `foobar` rather than site wide default value.
This is useful to me, because I would like to customise each pages of blog.
Could you please help to review it?
Thanks a lot. :smile: