### PR TITLE
Update the extension to work with Middleman 4.0

### DIFF
--- a/lib/middleman-meta-tags.rb
+++ b/lib/middleman-meta-tags.rb
@@ -2,5 +2,5 @@ require 'middleman-core'
 
 ::Middleman::Extensions.register(:meta_tags) do
   require 'middleman-meta-tags/extension'
-  ::Middleman::MetaTags
+  ::Middleman::MetaTagsExtension
 end

--- a/lib/middleman-meta-tags/extension.rb
+++ b/lib/middleman-meta-tags/extension.rb
@@ -2,9 +2,6 @@ require 'middleman-meta-tags/helpers'
 
 module Middleman
   class MetaTagsExtension < Extension
-    def initialize(app, options = {}, &block)
-      super
-      app.helpers Middleman::MetaTags::Helpers
-    end
+    self.defined_helpers = [ Middleman::MetaTags::Helpers ]
   end
 end

--- a/lib/middleman-meta-tags/extension.rb
+++ b/lib/middleman-meta-tags/extension.rb
@@ -1,11 +1,10 @@
 require 'middleman-meta-tags/helpers'
 
 module Middleman
-  module MetaTags
-    class << self
-      def registered(app, options_hash = {}, &block)
-        app.helpers Middleman::MetaTags::Helpers
-      end
+  class MetaTagsExtension < Extension
+    def initialize(app, options = {}, &block)
+      super
+      app.helpers Middleman::MetaTags::Helpers
     end
   end
 end


### PR DESCRIPTION
This PR changes the extension file to work with Middleman 4.0

Closes #6 

[:ok_hand: FIAS: 1 / 1 / 1 = 3](http://harvesthq.github.com/fias/?v1=1&v2=1&v3=1) -- (needs one +1)
