### PR TITLE
Calculate pull_image path with image_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Then it looks the page meta data to attempt to display the following keys:
 - MM `pull_image` => META `og:image`
 - MM `site` => META `og:site_name`
 - MM `title` => META `og:title`
+- MM `host` => optional attribute for composing `pull_image` src with asset helper
 
 In addition, if you want to customize meta tags by each page's frontmatter, you
 can add `customize_by_frontmatter: true` in `data/site.yml`. The priority would
@@ -104,6 +105,28 @@ end
 ```
 
 And add it to the layouts and views that you need.
+
+### Pull images
+
+For the `pull_image` to render for twitter metatags, a full url must be used:
+
+```
+pull_image: 'http://example.com/path/to/image.jpg'
+```
+
+If pointing to an image in your Middleman source, you can instead specify the
+relative image path as you would with an asset helper provided you have also
+configured the `host` in your `site.yml`. If your Middleman build activates
+extensions like `:asset_hash`, the full, hashed URL will be generated in your
+metatags.
+
+```
+# site.yml
+host: http://example.com
+
+# your article
+pull_image 'page/to/image/jpg'
+```
 
 ## Contributing
 

--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -68,13 +68,13 @@ module Middleman
         fall_through(site_data, 'twitter:card', 'twitter_card', 'summary_large_image')
         fall_through(site_data, 'twitter:creator', 'twitter_author')
         fall_through(site_data, 'twitter:description', 'description')
-        fall_through(site_data, 'twitter:image:src', 'pull_image')
+        fall_through_image(site_data, 'twitter:image:src', 'pull_image')
         fall_through(site_data, 'twitter:site', 'publisher_twitter')
         fall_through(site_data, 'twitter:title', 'title')
 
         # Open Graph
         fall_through(site_data, 'og:description', 'description')
-        fall_through(site_data, 'og:image', 'pull_image')
+        fall_through_image(site_data, 'og:image', 'pull_image')
         fall_through(site_data, 'og:title', 'title')
       end
 
@@ -86,8 +86,29 @@ module Middleman
                 (need_customized && current_page.data[key]) ||
                 site_data[key] ||
                 default
+        value = yield value if block_given?
         set_meta_tags name => value unless value.blank?
         value
+      end
+
+      def fall_through_image(*args)
+        fall_through(*args) do |path|
+          is_uri?(path) ? path : meta_tags_image_url(path)
+        end
+      end
+
+      def meta_tags_image_url(source)
+        meta_tags_host + image_path(source)
+      end
+
+      def meta_tags_host
+        (data['site'] || {})['host'] || ""
+      end
+
+      # borrowed from Rails 3
+      # http://apidock.com/rails/v3.2.8/ActionView/AssetPaths/is_uri%3F
+      def is_uri?(path)
+        path =~ %r{^[-a-z]+://|^(?:cid|data):|^//}
       end
 
       def full_title(meta_tags)

--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -102,7 +102,7 @@ module Middleman
       end
 
       def meta_tags_host
-        (data['site'] || {})['host'] || ""
+        (data['site'] || {})['host'] || ''
       end
 
       # borrowed from Rails 3


### PR DESCRIPTION
This patch allows you to specify pull image source as you would an argument to the `image_path` helper. In other words, any asset configuration (asset hashing, asset host, cache busting, etc) in your stack will be applied to the output.

So, in yml instead of

``` ruby
pull_image: 'http://example.com/assets/my/image.jpg
```

you may do:

``` ruby
pull_image: 'my/image.jpg
```

Either approach will work as expected, so backwards compatibility is maintained.

To make this work, a new `:host` option should be provided in `site.yml`.

``` ruby
# site.yml
site: 'My blog'
host: 'https://rossta.net'
pull_image: 'icon-ruby.png'
# ...
```
