### PR TITLE
Keywords can be an Array

### DIFF
--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -34,6 +34,7 @@ module Middleman
         result << tag(:meta, name: :description, content: description) unless description.blank?
 
         keywords = meta_tags.delete(:keywords)
+        keywords = keywords.join(', ') if keywords.is_a?(Array)
         result << tag(:meta, name: :keywords, content: keywords) unless keywords.blank?
 
         meta_tags.each do |name, content|


### PR DESCRIPTION
Hi!
Keyword list are often easier to maintain when it's presented as an `Array`. This update makes it possible.