### PR TITLE
i18n compatibility for title and meta tags

### DIFF
--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -88,6 +88,15 @@ module Middleman
                 site_data[key] ||
                 default
         value = yield value if block_given?
+
+        if key === "description"
+          value = safe_description(value)
+        end
+
+        if key === "title"
+          value = safe_title(value)
+        end
+
         set_meta_tags name => value unless value.blank?
         value
       end

--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -128,7 +128,7 @@ module Middleman
           description = description[I18n.locale]
         end
 
-        if description.start_with?('t:')
+        if description && description.start_with?('t:')
           description = I18n.t(description[2..-1])
         end
 
@@ -140,7 +140,7 @@ module Middleman
           title = title[I18n.locale]
         end
 
-        if title.start_with?('t:')
+        if title && title.start_with?('t:')
           title = I18n.t(title[2..-1])
         end
 

--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -124,10 +124,26 @@ module Middleman
       end
 
       def safe_description(description)
+        if description.is_a?(Hash) && description[I18n.locale]
+          description = description[I18n.locale]
+        end
+
+        if description.start_with?('t:')
+          description = I18n.t(description[2..-1])
+        end
+
         truncate(strip_tags(description), length: 200)
       end
 
       def safe_title(title)
+        if title.is_a?(Hash) && title[I18n.locale]
+          title = title[I18n.locale]
+        end
+
+        if title.start_with?('t:')
+          title = I18n.t(title[2..-1])
+        end
+
         title = strip_tags(title)
       end
     end


### PR DESCRIPTION
This change lets you define translations in frontmatter for title and description:

```
---
title: 
  en: English
  de: German
description:
  en: English
  de: German
---
```

Or you can define a translation key with a t: prefix, and just simply place your page titles and description in the locales folder alongside with other translations:

```
---
title: t:homepage_title
description: t:homepage_description
---
```