### PR TITLE
Add ability to not have images in meta data

### DIFF
--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -203,6 +203,7 @@ module Middleman
       end
 
       def meta_tags_image_url(source)
+        return nil unless source.present?
         File.join(meta_tags_host, image_path(source))
       end
 

--- a/spec/middleman-meta-tags/helpers_spec.rb
+++ b/spec/middleman-meta-tags/helpers_spec.rb
@@ -34,4 +34,28 @@ describe Middleman::MetaTags::Helpers do
     expect(h.display_meta_tags site: 'My Awesome Website').to eql('<title>My Awesome Website</title>
 <link rel="site" href="My Awesome Website" />')
   end
+
+  describe "meta_tags_image_url" do
+    before do
+      allow(h).to receive(:data).and_return(
+        {
+          "site" => {
+            "host" => "https://example.com"
+          }
+        }
+      )
+    end
+
+    it "returns a URL when image is given" do
+      expect(
+        h.send(:meta_tags_image_url, "/awesome/image.jpg")
+      ).to eq("https://example.com/awesome/image.jpg")
+    end
+
+    it "returns nil when image is nil" do
+      expect(
+        h.send(:meta_tags_image_url, nil)
+      ).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
With `auto_display_meta_tags` image tags are always generated, even if no images have been configured for a page, resulting in meta tags like:

    <meta itemprop="image" content="https://example.com/images/" />
    <meta name="twitter:image" content="https://example.com/images/" />
    <meta property="og:image" content="https://example.com/images/" />

Those URLs don't resolve to actual images and are simply defaults/faulty.

With this change in place, those faulty meta tags aren't output.