### PR TITLE
Allow viewport to be customized

### DIFF
--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -106,7 +106,6 @@ module Middleman
         author_data    = site_data['author'] || {}
 
         set_meta_tags charset:      'utf-8',
-                      viewport:     'width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no',
                       'http-equiv': 'IE=edge,chrome=1'
 
         fall_through(site_data, :site, 'name')
@@ -114,6 +113,7 @@ module Middleman
         fall_through(site_data, :title, 'title')
         fall_through(site_data, :description, 'description')
         fall_through(site_data, :keywords, 'keywords')
+        fall_through(site_data, :viewport, 'viewport', 'width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no')
 
         # Microdata
         fall_through(site_data,       'itemprop:name', 'name')

--- a/spec/middleman-meta-tags/helpers_spec.rb
+++ b/spec/middleman-meta-tags/helpers_spec.rb
@@ -46,6 +46,21 @@ describe Middleman::MetaTags::Helpers do
         '<meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" />'
       )
     end
+
+    it "prefers viewport from site data" do
+      allow(h).to receive(:data).and_return(
+        {
+          "site" => {
+            "viewport" => "width=device-width,user-scalable=yes"
+          }
+        }
+      )
+
+      tags = h.auto_display_meta_tags.split("\n")
+      expect(tags).to include(
+        '<meta name="viewport" content="width=device-width,user-scalable=yes" />'
+      )
+    end
   end
 
   describe "meta_tags_image_url" do

--- a/spec/middleman-meta-tags/helpers_spec.rb
+++ b/spec/middleman-meta-tags/helpers_spec.rb
@@ -35,6 +35,19 @@ describe Middleman::MetaTags::Helpers do
 <link rel="site" href="My Awesome Website" />')
   end
 
+  describe "auto_display_meta_tags" do
+    before do
+      allow(h).to receive(:data).and_return({})
+    end
+
+    it "includes a viewport tag" do
+      tags = h.auto_display_meta_tags.split("\n")
+      expect(tags).to include(
+        '<meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" />'
+      )
+    end
+  end
+
   describe "meta_tags_image_url" do
     before do
       allow(h).to receive(:data).and_return(


### PR DESCRIPTION
Without this the viewport meta tag value was always hardcoded to

    width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no

when using auto_display_meta_tags.

After this change it is now possible to customize the viewport value
either in site.yml or in page frontmatter.