### PR TITLE
Add middleman 4.4 support

### DIFF
--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/hash/indifferent_access"
+
 module Middleman
   module MetaTags
     module Helpers

--- a/spec/middleman-meta-tags/helpers_spec.rb
+++ b/spec/middleman-meta-tags/helpers_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+require 'middleman-core/core_extensions/data'
+
 describe Middleman::MetaTags::Helpers do
   let(:h) { Class.new { extend Middleman::MetaTags::Helpers } }
 
@@ -84,6 +86,33 @@ describe Middleman::MetaTags::Helpers do
       expect(
         h.send(:meta_tags_image_url, nil)
       ).to be_nil
+    end
+  end
+
+  describe "site_data" do
+    before do
+      app = :app
+      data_store = Middleman::CoreExtensions::Data::DataStore.new(
+        app,
+        Middleman::CoreExtensions::Data::DATA_FILE_MATCHER
+      )
+      data_store.store(
+        :site,
+        {
+          :host => "https://middlemanapp.com/",
+          :site => "Middleman",
+        }
+      )
+      allow(h).to receive(:data).and_return(data_store)
+    end
+
+    it "returns a HashWithIndifferentAccess" do
+      expect(h.site_data).to be_a(ActiveSupport::HashWithIndifferentAccess)
+    end
+
+    it "returns data from the :site key" do
+      expect(h.site_data['site']).to eq("Middleman")
+      expect(h.site_data[:site]).to eq("Middleman")
     end
   end
 end


### PR DESCRIPTION
Without this `site_data` ends up returning `nil` on Middleman 4.4.

`data` from Middleman returns a `Middleman::CoreExtensions::Data::DataStore`, and `data['site']` returns a `Middleman::Util::EnhancedHash`. That is all fine.

However, we then end up calling `with_indifferent_access` on the `EnhancedHash`, which hits `EnhancedHash#method_missing` because `with_indifferent_access` isn't defined. That `method_missing` call then
returns `nil` which is what `site_data` ends up returning, breaking all subsequent `[]` accesses.

I am guessing Middleman 4.4 stopped requiring `"active_support/core_ext/hash/indifferent_access"` and we've relied on that until now, although I haven't been able to verify that.

This fixes #25, #26 as far as I can tell.


